### PR TITLE
Move visualizing and debugging loops content before PSet

### DIFF
--- a/nested-data-and-nested-loops/nested-loops.md
+++ b/nested-data-and-nested-loops/nested-loops.md
@@ -83,6 +83,63 @@ Tracing the logic going from the outermost to the innermost code, we loop throug
 
 The function ultimately returns `char_map` . Before we invoke the `map_character_frequency` function, we create a list of words in `colors`. We pass the `colors` list into the function. When we get the character frequency map back, we print it to the console.
 
+## Visualizing Loops in Loops
+
+Sometimes it can be challenging to visualize how a particular loop runs. A _**loop table**_ is a tool we can use to help us visualize the operation of loops, both nested and unnested. Let's use our now-familiar character counting code as an example.
+
+```python
+def map_character_frequency(words):
+    char_map = {}
+    for word in words:
+        for character in word:
+            if character not in char_map:
+                char_map[character] = 1
+            else:
+                char_map[character] += 1
+    return char_map
+
+words = ["deer", "reads"]
+
+char_map = map_character_frequency(words)
+print(char_map)
+```
+
+| `word`  | `character` | `char_map`                                 |
+| ------- | ----------- | ------------------------------------------ |
+| `deer`  | `d`         | `{"d": 1}`                                 |
+| `deer`  | `e`         | `{"d": 1, "e": 1}`                         |
+| `deer`  | `e`         | `{"d": 1, "e": 2}`                         |
+| `deer`  | `r`         | `{"d": 1, "e": 2, "r": 1}`                 |
+| `reads` | `r`         | `{"d": 1, "e": 2, "r": 2}`                 |
+| `reads` | `e`         | `{"d": 1, "e": 3, "r": 2}`                 |
+| `reads` | `a`         | `{"d": 1, "e": 3, "r": 2, "a": 1}`         |
+| `reads` | `d`         | `{"d": 2, "e": 3, "r": 2, "a": 1}`         |
+| `reads` | `s`         | `{"d": 2, "e": 3, "r": 2, "a": 1, "s": 1}` |
+
+At this point, there are no more characters and no more words to loop through.
+
+## Writing Loops in Loops
+
+Writing loops in loops has no special syntax. However, here are some tips and and steps to consider and follow.
+
+Logical errors are the most common errors with nested loops. Attempt to have a clear goal in mind:
+
+- What are you looping through?
+- Why do you need to nest these loops? Could we solve this without nested loops?
+- How can I prove to myself that my loops are working as intended?
+
+### Debugging Loops in Loops
+
+Debugging loops in loops is extremely challenging when we're unclear about how many loops are happening, and the state of the code at any given moment.
+
+When debugging, prioritize the process of stepping through each loop and checking each variable. Check each variable in each loop using:
+
+- a debugger tool
+- paper and pencil, write down each variable
+- a loop table
+- `print` statements
+
+
 ### Practice
 
 Read through this code and answer these questions.
@@ -104,6 +161,12 @@ colors_char_map = map_character_frequency(colors)
 print(colors_char_map)
 ```
 
+### Tips
+
+- Use indentation to understand the nesting
+- Take time to understand the local variables in each loop
+- Use words, comments, and pseudocode, and use the phrase "for each ..., we do ..." and "while ... is true, we do ..."
+- 
 <!-- Question 1 -->
 
 <!-- prettier-ignore-start -->
@@ -269,64 +332,5 @@ What is the local variable for each item in `word` ?
 ### !end-challenge
 <!-- prettier-ignore-end -->
 
-### Tips
 
-- Use indentation to understand the nesting
-- Take time to understand the local variables in each loop
-- Use words, comments, and pseudocode, and use the phrase "for each ..., we do ..." and "while ... is true, we do ..."
 
-## Visualizing Loops in Loops
-
-Sometimes it can be challenging to visualize how a particular loop runs. A _**loop table**_ is a tool we can use to help us visualize the operation of loops, both nested and unnested. Let's use our now-familiar character counting code as an example.
-
-```python
-def map_character_frequency(words):
-    char_map = {}
-    for word in words:
-        for character in word:
-            if character not in char_map:
-                char_map[character] = 1
-            else:
-                char_map[character] += 1
-    return char_map
-
-words = ["deer", "reads"]
-
-char_map = map_character_frequency(words)
-print(char_map)
-```
-
-| `word`  | `character` | `char_map`                                 |
-| ------- | ----------- | ------------------------------------------ |
-| `deer`  | `d`         | `{"d": 1}`                                 |
-| `deer`  | `e`         | `{"d": 1, "e": 1}`                         |
-| `deer`  | `e`         | `{"d": 1, "e": 2}`                         |
-| `deer`  | `r`         | `{"d": 1, "e": 2, "r": 1}`                 |
-| `reads` | `r`         | `{"d": 1, "e": 2, "r": 2}`                 |
-| `reads` | `e`         | `{"d": 1, "e": 3, "r": 2}`                 |
-| `reads` | `a`         | `{"d": 1, "e": 3, "r": 2, "a": 1}`         |
-| `reads` | `d`         | `{"d": 2, "e": 3, "r": 2, "a": 1}`         |
-| `reads` | `s`         | `{"d": 2, "e": 3, "r": 2, "a": 1, "s": 1}` |
-
-At this point, there are no more characters and no more words to loop through.
-
-## Writing Loops in Loops
-
-Writing loops in loops has no special syntax. However, here are some tips and and steps to consider and follow.
-
-Logical errors are the most common errors with nested loops. Attempt to have a clear goal in mind:
-
-- What are you looping through?
-- Why do you need to nest these loops? Could we solve this without nested loops?
-- How can I prove to myself that my loops are working as intended?
-
-### Debugging Loops in Loops
-
-Debugging loops in loops is extremely challenging when we're unclear about how many loops are happening, and the state of the code at any given moment.
-
-When debugging, prioritize the process of stepping through each loop and checking each variable. Check each variable in each loop using:
-
-- a debugger tool
-- paper and pencil, write down each variable
-- a loop table
-- `print` statements


### PR DESCRIPTION
Addresses:
There is important content on visualizing and debugging nested loops that comes after the practice problems on the "Nested Loops" lesson. Wondering if it's worth moving that content above the practice questions or adding a final takeaways question at the end to ensure folks have gotten to that content? 

Summary of Changes:
- Moves Visualizing, Writing, and Debugging loops section before practice questions
- Moves tips after practice intro but before challenge questions